### PR TITLE
Import `index` from `Matrix` to make sure `index` class definition is always available

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,3 +7,4 @@ S3method("print","brob")
 S3method("print","glub")
 S3method("print","brobmat")
 
+importClassesFrom(Matrix,index)


### PR DESCRIPTION
Should solve https://github.com/RobinHankin/Brobdingnag/issues/20 and https://github.com/tidyverse/dbplyr/issues/779.